### PR TITLE
Add top/bottom padding to Connected Item rows in admin

### DIFF
--- a/admin/box.css
+++ b/admin/box.css
@@ -50,8 +50,7 @@
 .p2p-connections th,
 .p2p-connections td,
 .p2p-results td {
-	padding-left: 6px;
-	padding-right: 6px;
+	padding:6px;
 }
 
 th.p2p-col-delete,


### PR DESCRIPTION
Fixes display for long titles that wrap onto 2+ lines that are squashed
vertically against the lines at the top and bottom of the row.
