### PR TITLE
Admin box 'Delete all connections' title displays all_items label rather than singular_name

### DIFF
--- a/admin/box.php
+++ b/admin/box.php
@@ -46,7 +46,7 @@ class P2P_Box {
 
 		$this->columns = array(
 			'delete' => new P2P_Field_Delete,
-			'title' => new $title_class( $this->labels->singular_name ),
+			'title' => new $title_class( $this->labels->all_items ),
 		);
 
 		foreach ( $this->args->fields as $key => $data ) {


### PR DESCRIPTION
This is my first git attempt.  So far I like it much more than svn.  Anyway, as you already mentioned, this is not a bug fix... just a learning experiment.  Not to worry, I handle rejection well ;)
-Baden
