### PR TITLE
Replace a continue with a return.

### DIFF
--- a/admin/box-factory.php
+++ b/admin/box-factory.php
@@ -45,7 +45,7 @@ class P2P_Box_Factory extends P2P_Factory {
 
 	function add_item( $directed, $object_type, $post_type, $title ) {
 		if ( !self::show_box( $directed, $GLOBALS['post'] ) )
-			continue;
+			return;
 
 		$box = $this->create_box( $directed );
 		$box_args = $this->queue[ $directed->name ];


### PR DESCRIPTION
If the filter 'p2p_admin_box_show' returns false, you'll get a PHP error because the function add_item uses a 'continue' in lieu of a 'return.'
