### PR TITLE
Fixes #217

### DIFF
--- a/core/url-query.php
+++ b/core/url-query.php
@@ -24,7 +24,7 @@ class P2P_URL_Query {
 			return;
 
 		// Restrict to users screen
-		if ( 'users' != get_current_screen()->id )
+		if ( get_current_screen() && 'users' != get_current_screen()->id )
 			return;
 
 		// Don't overwrite capturing query


### PR DESCRIPTION
Check to make sure get_current_screen doesn't simply return null before
objectifying it.

"Notice: Trying to get property of non-object in
/.../wordpress/wp-content/plugins/posts-to-posts/core/url-query.php on
line 27"
