### PR TITLE
Fix connection with pending and draft posts

### DIFF
--- a/core/query.php
+++ b/core/query.php
@@ -112,6 +112,7 @@ class P2P_Query {
 		$side = $directed->get( $which, 'side' );
 
 		$qv = array_merge( $this->query, array(
+			'post_status' => 'any',
 			'fields' => 'ids',
 			'p2p:per_page' => -1
 		) );


### PR DESCRIPTION
Connected query returns no posts when status 'draft' or 'pending'

More about issue in: https://github.com/scribu/wp-posts-to-posts/issues/240

_Note: There might be some dependencies with post statuses about which I don't know._
