### PR TITLE
Check if attachment is an image before showing the thumbnail

### DIFF
--- a/core/item.php
+++ b/core/item.php
@@ -70,7 +70,10 @@ class P2P_Item_Post extends P2P_Item {
 class P2P_Item_Attachment extends P2P_Item_Post {
 
 	function get_title() {
-		return wp_get_attachment_image( $this->item->ID, 'thumbnail', false );
+		if( wp_attachment_is_image( $this->item->ID ) )
+			return wp_get_attachment_image( $this->item->ID, 'thumbnail', false );
+
+		return get_the_title( $this->item );
 	}
 }
 


### PR DESCRIPTION
When you now retrieve the title of an attachment it always trying to show a thumbnail. This only works for images and not for the rest. It now uses wp_get_attachment_image() to check if it's an image.
