### PR TITLE
get_prev() and get_next() should not return P2P_Item

### DIFF
--- a/core/connection-type.php
+++ b/core/connection-type.php
@@ -309,7 +309,12 @@ class P2P_Connection_Type {
 			)
 		), 'abstract' );
 
-		return _p2p_first( $adjacent->items );
+		if ( empty( $adjacent->items ) )
+			return false;
+
+		$item = reset( $adjacent->items );
+
+		return $item->get_object();
 	}
 
 	/**
@@ -350,15 +355,9 @@ class P2P_Connection_Type {
 
 		$parent = $connected_series[0];
 
-		$result['parent'] = $parent;
+		$result['parent'] = $parent->get_object();
 		$result['previous'] = $this->get_previous( $item->ID, $parent->ID );
 		$result['next'] = $this->get_next( $item, $parent );
-
-		// unwrap
-		foreach ( $result as &$value ) {
-			if ( $value )
-				$value = $value->get_object();
-		}
 
 		return $result;
 	}

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -441,7 +441,7 @@ class P2P_Tests_Core extends WP_UnitTestCase {
 
 		$next = $ctype->get_next( $movie_ids[1], $actor );
 		$this->assertEquals( $next->ID, $movie_ids[2] );
-		$this->assertFalse( $$next instanceof P2P_Item );
+		$this->assertFalse( $next instanceof P2P_Item );
 	}
 
 	function test_adjacent_items() {


### PR DESCRIPTION
That's because functions such as `get_permalink()` don't work with P2P_Item_Post.

http://wordpress.org/support/topic/get_related-only-next-and-previous-post

Related: #324 
