### PR TITLE
add custom column before the post_date

### DIFF
--- a/admin/column.php
+++ b/admin/column.php
@@ -28,7 +28,7 @@ abstract class P2P_Column {
 			? $labels->column_title
 			: $this->ctype->get( 'current', 'title' );
 
-		return array_splice($columns, 0, -1) + array($this->column_id => $title) + $columns;
+		return array_splice( $columns, 0, -1 ) + array( $this->column_id => $title ) + $columns;
 	}
 
 	protected abstract function get_items();


### PR DESCRIPTION
Hi scribu, 

I really enjoy your plugin! I prefer to have all of my custom columns added before the post_date column in the admin UI. Not sure what most people prefer, but it seems like a best practice to me. Anyways, this PR adds all custom columns before the post_date column in the admin UI.
