### PR TITLE
Fixes P2P_URL_Query class not being loaded by Autoload

### DIFF
--- a/core/init.php
+++ b/core/init.php
@@ -11,6 +11,8 @@ P2P_Storage::init();
 P2P_Query_Post::init();
 P2P_Query_User::init();
 
+P2P_URL_Query::init();
+
 P2P_Widget::init();
 P2P_Shortcodes::init();
 

--- a/core/url-query.php
+++ b/core/url-query.php
@@ -16,5 +16,3 @@ class P2P_URL_Query {
 	}
 }
 
-P2P_URL_Query::init();
-


### PR DESCRIPTION
Hi Scribu, the query parameters were not working in the admin ui (more specifically the links in admin column) since version 1.5 because this class was not being loaded by the new autoload system.

Bug was introduced with commit 90e2ecb630232e4feeeb50e79c4b46cbd519a2b5 (first pass at autoloading core classes)
