### PR TITLE
Replace each_connected() with something less confusing

### DIFF
--- a/core/connections-map.php
+++ b/core/connections-map.php
@@ -1,0 +1,17 @@
+<?php
+
+class P2P_Connections_Map {
+
+	private $directed;
+	private $buckets;
+
+	function __construct( $items, $directed ) {
+		$this->buckets = scb_list_group_by( $items, '_p2p_get_other_id' );
+		$this->directed = $directed;
+	}
+
+	function _for( $item ) {
+		return $this->buckets[ $item->ID ];
+	}
+}
+

--- a/tests/test-core.php
+++ b/tests/test-core.php
@@ -364,14 +364,23 @@ class P2P_Tests_Core extends WP_UnitTestCase {
 			'order' => 'ASC'
 		) );
 
-		$ctype->each_connected( $query );
+		$connected = $ctype->connected_many( $query );
+		if ( is_wp_error( $connected ) )
+			throw new Exception('WTF');
 
-		$this->assertEquals( $query->posts[0]->connected[0]->ID, $movie->ID );
-		$this->assertEquals( $query->posts[1]->connected[0]->p2p_id, $p2p_id_1 );
-		$this->assertEmpty( $query->posts[2]->connected );
+		var_dump( wp_list_pluck( $query->posts, 'ID' ) );
+		var_dump( $connected );
+
+		$connected_for_0 = $connected->_for( $query->posts[0] );
+		$connected_for_1 = $connected->_for( $query->posts[1] );
+		$connected_for_2 = $connected->_for( $query->posts[2] );
+
+		$this->assertEquals( $connected_for_0[0]->ID, $movie->ID );
+		$this->assertEquals( $connected_for_0[1]->p2p_id, $p2p_id_1 );
+		$this->assertEmpty( $connected_for_2 );
 
 		// Test that connected posts have real properties
-		$properties = get_object_vars( $query->posts[0]->connected[0] );
+		$properties = get_object_vars( $connected_for_0[0] );
 		$this->assertTrue( isset( $properties['post_type'] ) );
 	}
 


### PR DESCRIPTION
`each_connected()` is confusing because it doesn't return anything; instead, it produces side-effects on the $wp_query object.

It would be better if it returned something which the user could explicitly manipulate.

Proposed syntax:

``` php
$connected_locations = p2p_type( 'posts_to_locations' )->connected_many( $wp_query );
$connected_pages = p2p_type( 'pages_to_posts' )->connected_many( $wp_query );

while ( have_posts() ) : the_post();

    foreach ( $connected_locations->for( $post ) as $post ) : setup_postdata( $post );
        the_title();
    endforeach;
    wp_reset_postdata();

    foreach ( $connected_pages->for( $post ) as $post ) : setup_postdata( $post );
        the_title();
    endforeach;
    wp_reset_postdata();

endwhile;
```

cc: @markjaquith, @aaroncampbell
### History

Initially, all the querying was done through WP_Query query vars (including 'each_connected').

Then, the idea of explicit connection types came along and the query vars were replaced with `P2P_Connection_Type->get_connected()`.

Then, the preference went back to query vars (#61).
