### PR TITLE
Stop triggering warnings from inside the query

### DIFF
--- a/core/query-post.php
+++ b/core/query-post.php
@@ -13,7 +13,7 @@ class P2P_Query_Post {
 		$r = P2P_Query::create_from_qv( $wp_query->query_vars, 'post' );
 
 		if ( is_wp_error( $r ) ) {
-			trigger_error( $r->get_error_message(), E_USER_WARNING );
+			$wp_query->_p2p_error = $r;
 
 			$wp_query->set( 'year', 2525 );
 			return;

--- a/core/query-user.php
+++ b/core/query-user.php
@@ -12,7 +12,7 @@ class P2P_Query_User {
 		$r = P2P_Query::create_from_qv( $query->query_vars, 'user' );
 
 		if ( is_wp_error( $r ) ) {
-			trigger_error( $r->get_error_message(), E_USER_WARNING );
+			$query->_p2p_error = $r;
 
 			$query->query_where = " AND 1=0";
 			return;


### PR DESCRIPTION
Remove calls to trigger_error() from inside the queries handlers and populate $query->_p2p_error instead.

Fixes #379
