### PR TITLE
Validate that connection exists before saving meta

### DIFF
--- a/admin/box-factory.php
+++ b/admin/box-factory.php
@@ -97,6 +97,9 @@ class P2P_Box_Factory extends P2P_Factory {
 
 				$connection = p2p_get_connection( $p2p_id );
 
+				if ( ! $connection )
+					continue;
+
 				$fields = p2p_type( $connection->p2p_type )->fields;
 
 				foreach ( $fields as $key => &$field ) {


### PR DESCRIPTION
If connection doesn't exist, user will get warnings _Invalid argument supplied for foreach()_ in `P2P_Box_Factory::save_post()` and `scbForms::update_meta()`.

I reproduced this while creating duplicates of posts with connections using plugin Multilingual Press, [on](https://github.com/inpsyde/multilingual-press/blob/0fa71e21f00098bb642fb7e5b56fe7c487cc4b1f/multilingual-press.php#L622) `save_post` it uses `switch_to_blog()` and then `wp_insert_post()` to create duplicate and since `save_post` is called then, `P2P_Box_Factory::save_post()` will be fired which will use connection that doesn't exists or is wrong.
