### PR TITLE
Add support for dropdown filter default option text

### DIFF
--- a/admin/dropdown.php
+++ b/admin/dropdown.php
@@ -18,7 +18,12 @@ abstract class P2P_Dropdown {
 		$direction = $this->ctype->flip_direction()->get_direction();
 		
 		$labels = $this->ctype->get( 'current', 'labels' );
-		$title = isset( $labels->dropdown_title ) ? $labels->dropdown_title : $this->title;
+		if ( isset( $labels->dropdown_title ) )
+			$title = $labels->dropdown_title;
+		elseif( isset( $labels->column_title ) )
+			$title = $labels->column_title;
+		else
+			$title = $this->title;
 
 		return scbForms::input( array(
 			'type' => 'select',


### PR DESCRIPTION
Add support for dropdown filter default option text, just like column headings.

Use 'dropdown_title' as the from / to label key:

``` php
p2p_register_connection_type( array(
  ...
  'from' => 'actor',
  'to' => 'movie',
  'admin_column' => 'any',
  'from_labels' => array(
    'dropdown_title' => 'Connected Actors',
    ...
  ),
  'to_labels' => array(
    'dropdown_title' => 'Connected Movies',
    ...
  ),
) );
```
