### PR TITLE
Changed the way a column's link is generated

### DIFF
--- a/admin/column-post.php
+++ b/admin/column-post.php
@@ -21,10 +21,16 @@ class P2P_Column_Post extends P2P_Column {
 			'connected_type' => $this->ctype->name,
 			'connected_direction' => $this->ctype->flip_direction()->get_direction(),
 			'connected_items' => $item->get_id(),
-			'post_type' => get_current_screen()->post_type
+			'action' => 'edit'
 		);
 
-		return add_query_arg( $args, admin_url( 'edit.php' ) );
+		if($item instanceof P2P_Item_User) {
+			$args['user_id'] = $item->get_id();
+			return add_query_arg($args, admin_url('user-edit.php'));
+		} else {
+			$args['post'] = $item->get_id();
+			return add_query_arg( $args, admin_url( 'post.php' ) );
+		}
 	}
 
 	function display_column( $column, $item_id ) {


### PR DESCRIPTION
When you click on a relation's link in the admin, it'll go to the edit page of the corresponding post (before it redirected to the current page with additional query vars). I don't really know if that's what supposed to happen but here's my attempt to a fix.
