### PR TITLE
Activation conflict with a bundled version of Posts to Posts core

### DIFF
--- a/posts-to-posts.php
+++ b/posts-to-posts.php
@@ -19,6 +19,7 @@ require_once dirname( __FILE__ ) . '/scb/load.php';
 function _p2p_load() {
 	load_plugin_textdomain( P2P_TEXTDOMAIN, '', basename( dirname( __FILE__ ) ) . '/lang' );
 
+	// Prevent activation issues if a bundled version of P2P core is already loaded.
 	if ( function_exists( 'p2p_register_connection_type' ) ) {
 		return;
 	}


### PR DESCRIPTION
If a plugin or theme is activated that has a bundled version of Posts to Posts core, trying to activate this plugin throws errors and it can't be activated. It will work if Posts to Posts is activated before the plugin or theme with the bundled version.

I couldn't seem to work around the sorcery in `scb_init()`, so adding the same check for `p2p_register_connection_type` from the [bundling instruction](https://github.com/AppThemes/wp-posts-to-posts-core/wiki/Bundling-in-a-plugin) seemed like the best route.
