### PR TITLE
Fix action 'parse_query' multi-trigger issues

### DIFF
--- a/core/query-post.php
+++ b/core/query-post.php
@@ -22,7 +22,9 @@ class P2P_Query_Post {
 		if ( null === $r )
 			return;
 
-		list( $wp_query->_p2p_query, $wp_query->query_vars ) = $r;
+		list( $wp_query->_p2p_query, $query_vars ) = $r;
+                
+                $wp_query->query_vars = array_merge( $wp_query->query_vars, $query_vars );
 
 		$wp_query->is_home = false;
 		$wp_query->is_archive = true;


### PR DESCRIPTION
Some themes/plugins will call `$query->parse_query();` during the `'pre_get_posts'` filter.

However `P2P_Query::create_from_qv` do not return back full `query_vars` which lost the `connected_type` settings.

The fix just merge the return values and pre-settings, to avoid such issues.
