### PR TITLE
Added a filter hook to the get_choices method of the P2P_Dropdown class

### DIFF
--- a/admin/dropdown.php
+++ b/admin/dropdown.php
@@ -61,7 +61,9 @@ abstract class P2P_Dropdown {
 			'p2p:context' => 'admin_dropdown'
 		);
 
-		$connected = $directed->get_connected( 'any', $extra_qv, 'abstract' );
+		$filtered_qv = apply_filters( 'p2p_post_admin_dropdown_query', $extra_qv );
+
+		$connected = $directed->get_connected( 'any', $filtered_qv, 'abstract' );
 
 		$options = array();
 		foreach ( $connected->items as $item )


### PR DESCRIPTION
This adds a filter to the query for admin dropdowns. The most notable use case for this would be for ordering connected items by name for a better UI.

You can hook into the filter **'p2p_post_admin_dropdown_query'**

Example:

``` php
// Register connection from author to book post types
p2p_register_connection_type(array(
    'name' => 'authors_to_books',
    'from' => 'author',
    'to' => 'book',
    'admin_dropdown' => 'to',
    'admin_column' => 'to',
));

function sort_p2p_dropdown_by_name( $query ){
  $args = array(
    'orderby' => 'name',
    'order' => 'asc',
  );
  return array_merge( $query, $args );
}
add_filter( 'p2p_post_admin_dropdown_query', 'sort_p2p_dropdown_by_name' );
```
