### PR TITLE
Limit search frequency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Posts 2 Posts
 
-Contributors: scribu, ciobi  
+Contributors: scribu, ciobi, ohryan  
 Tags: connections, custom post types, relationships, many-to-many, users  
 Requires at least: 3.9  
-Tested up to: 4.3  
+Tested up to: 5.3.2  
 Stable tag: 1.6.5  
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  

--- a/admin/box.js
+++ b/admin/box.js
@@ -225,7 +225,10 @@
       delayed = setTimeout(function() {
         var searchStr;
         searchStr = $searchInput.val();
-        if (searchStr === _this.collection.get('s')) {
+        if (
+            searchStr === _this.collection.get('s') ||
+            searchStr.length < 3
+        ) {
           return;
         }
         _this.spinner.insertAfter($searchInput).show();
@@ -233,7 +236,7 @@
           's': searchStr,
           'paged': 1
         });
-      }, 400);
+      }, 800);
     },
 
     changePage: function(ev) {

--- a/posts-to-posts.php
+++ b/posts-to-posts.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Posts 2 Posts
 Description: Create many-to-many relationships between all types of posts.
-Version: 1.6.5
+Version: 1.6.6
 Author: scribu
 Author URI: http://scribu.net/
 Plugin URI: http://scribu.net/wordpress/posts-to-posts


### PR DESCRIPTION
When the wp-admin side widget fires a search query on a site with a large amount of posts it tends to be slow and cpu intensive.
In this commit we introduce a search minimum search query length of 3. This resolves an issue where short queries (especially single
character) essentially match the entire database. By introducing the query min length with delay the first db query until the user is
more likely to have entered a full word.

We also increase the search handler timeout, to decrease the frequency with which the plugin will hit the db.