### PR TITLE
Added private property to class to resolve deprecated message

### DIFF
--- a/admin/box.php
+++ b/admin/box.php
@@ -10,6 +10,10 @@ class P2P_Box {
 
 	private $columns;
 
+    private $labels;
+
+    private $connected_items;
+
 	private static $enqueued_scripts = false;
 
 	private static $admin_box_qv = array(


### PR DESCRIPTION
Creation of dynamic property is deprecated in new PHP version so we are getting these messages
![deprecated](https://github.com/scribu/wp-posts-to-posts/assets/6133482/2073c116-094b-49cb-a9ac-fbe1a896b067)
![deprecated1](https://github.com/scribu/wp-posts-to-posts/assets/6133482/43f9cec2-12af-4034-aa7a-039e82637ea9)

Now added private property to class to resolve deprecated message